### PR TITLE
Validate extension ID. Add docs for the API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,32 @@ While not the primary purpose, it is possible to use the Monkey Patch extension 
 ]
 ```
 
+## Using Monkey Patch through the API
+
+```js
+let monkeyPatch = vscode.extensions.getExtension("iocave.monkey-patch");
+
+if (monkeyPatch !== undefined) {
+    monkeyPatch.exports.contribute("<publisher>.<extension_name>",
+        {
+            folderMap: {
+                "my-custom-modules": path.join(this.context.extensionPath, "custom-modules"),
+            },
+            browserModules: [
+                "my-custom-modules/browser1"
+            ],
+            mainProcessModules: [
+                "my-custom-modules/mainProcess1",
+            ]
+        }
+    );
+} else {
+    vscode.window.showWarningMessage("Monkey Patch extension is not installed. This extension will not work.");
+}
+```
+
+For a full project that uses this, see https://github.com/iocave/customize-ui.
+
 ## If something goes wrong
 
 Monkey Patching can get fragile at times. If VSCode is running, you can unpach VSCode by invoking the "Disable Monkey Patch" command. If VSCode does launch, you can always redownload VSCode and replace the patched instance.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -203,7 +203,7 @@ class Extension {
 				}
 
 				this.lastMessageTimeBrowser = new Date().getTime();
-				let res = await vscode.window.showInformationMessage("Monkey Patch configuration has changed. Please RESTART your VSCode window!", "Reload");
+				let res = await vscode.window.showInformationMessage("Monkey Patch configuration has changed. Please RELOAD your VSCode window!", "Reload");
 				if (res === "Reload") {
 					vscode.commands.executeCommand("workbench.action.reloadWindow");
 				}
@@ -310,6 +310,9 @@ class Extension {
 	}
 
 	contribute(sourceExtensionId: string, contribution: Contribution) {
+		if (vscode.extensions.getExtension(sourceExtensionId) === undefined) {
+			throw new Error(`"${sourceExtensionId}" is not a valid extension id. Make sure you have "publisher" set in your package.json, and pass in "<publisher>.<name>"`);
+		}
 		this.contributions[sourceExtensionId] = contribution;
 		this.saveContributions();
 		this.configurationChanged();


### PR DESCRIPTION
First of all, thank you for this project! Exactly what I was looking for.

I discovered that if you pass in an invalid extension ID to `contribute()`, things get pretty broken. It will keep prompting you to reload the window every time it loads. I added some validation so it will throw an exception instead.

I also added some docs about the API to the readme. (Discovering https://github.com/iocave/customize-ui made things a lot more clear.)