### PR TITLE
[Re]fix baseUrl for Insiders in bootstrap-amd.js + patch version bump

### DIFF
--- a/data/bootstrap-amd.js
+++ b/data/bootstrap-amd.js
@@ -12,9 +12,18 @@ const bootstrap = require('./bootstrap');
 // Bootstrap: NLS
 const nlsConfig = bootstrap.setupNLS();
 
+// Resolve for code or code-insiders
+const baseUrl = bootstrap.fileUriFromPath
+    // Code - Insiders
+    ? bootstrap.fileUriFromPath(__dirname, {
+        isWindows: "win32" === process.platform,
+    })
+    // Code
+    : bootstrap.uriFromPath(__dirname);
+
 // Bootstrap: Loader
 loader.config({
-	baseUrl: bootstrap.uriFromPath(__dirname),
+	baseUrl,
 	catchError: true,
 	nodeRequire: require,
 	nodeMain: __filename,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "monkey-patch",
 	"displayName": "Monkey Patch",
 	"description": "Inject custom javascript into vscode",
-	"version": "0.1.10",
+	"version": "0.1.11",
 	"publisher": "iocave",
 	"author": {
 		"email": "matej.knopp@gmail.com",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "monkey-patch",
 	"displayName": "Monkey Patch",
 	"description": "Inject custom javascript into vscode",
-	"version": "0.1.9",
+	"version": "0.1.10",
 	"publisher": "iocave",
 	"author": {
 		"email": "matej.knopp@gmail.com",


### PR DESCRIPTION
Since the patch in version `0.1.10`, `fileUriFromPath` now has (and uses in `bootstrap-amd.js`) an additional parameter:

``` ts
interface FileFromPathConfig 
{
    scheme?: string;
    isWindows?: boolean;
    fallbackAuthority?: string;
}
function fileUriFromPath(path: string, config: FileFromPathConfig): string
```

This PR updates fixes its use in `bootstrap-amd.js` for Code - Insiders (and also doesn't break Code), and bumps the patch version—I don't think its in the repo atm, so here's the latest marketplace version	 for reference:

``` js
// Bootstrap: Loader
loader.config({
	baseUrl: bootstrap.fileUriFromPath ? bootstrap.fileUriFromPath(__dirname) : bootstrap.uriFromPath(__dirname),
	catchError: true,
	nodeRequire: require,
	nodeMain: __filename,
	'vs/nls': nlsConfig,
	paths : {
		"monkey": "[[MONKEY_PATCH_ROOT]]",
	}
});
```

Tested with versions:
- Insiders: `1.50.0-insiders`
- Code: `1.49.2`
