### PR TITLE
fix: update bootstrap-amd for recent upstream changes

### DIFF
--- a/data/bootstrap-amd.js
+++ b/data/bootstrap-amd.js
@@ -6,6 +6,18 @@
 //@ts-check
 'use strict';
 
+// Store the node.js require function in a variable
+// before loading our AMD loader to avoid issues
+// when this file is bundled with other files.
+const nodeRequire = require;
+
+// VSCODE_GLOBALS: node_modules
+globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), { get: (_target, mod) => nodeRequire(String(mod)) });
+
+// VSCODE_GLOBALS: package/product.json
+globalThis._VSCODE_PRODUCT_JSON = require('../product.json');
+globalThis._VSCODE_PACKAGE_JSON = require('../package.json');
+
 const loader = require('./vs/loader');
 const bootstrap = require('./bootstrap');
 
@@ -25,7 +37,7 @@ const baseUrl = bootstrap.fileUriFromPath
 loader.config({
 	baseUrl,
 	catchError: true,
-	nodeRequire: require,
+	nodeRequire,
 	nodeMain: __filename,
 	'vs/nls': nlsConfig,
 	paths : {
@@ -70,8 +82,8 @@ exports.load = function (entrypoint, onLoad, onError) {
 	// The best approach for now seem to be to load monkey patch immediately
 	// after the main.js file is read.
 	if (entrypoint === "vs/code/electron-main/main") {
-		let fs = require('fs');
-		let p = require('path');
+		let fs = nodeRequire('fs');
+		let p = nodeRequire('path');
 		let readFile = fs.readFile;
 		fs.readFile = function (path, options, callback) {
 			readFile(path, options, function () {


### PR DESCRIPTION
Upstream changes:

https://github.com/microsoft/vscode/pull/161161
https://github.com/microsoft/vscode/pull/166686

This partly fixes https://github.com/iocave/monkey-patch/issues/56, https://github.com/iocave/monkey-patch/issues/34 and https://github.com/iocave/monkey-patch/issues/55, such that the UI should still appear after monkey-patch is installed.

Fixing customize-ui and other downstream monkey-patching extensions will require a patch in VSCodium for now (Which I did a proof of concept at https://github.com/VSCodium/vscodium/compare/master...forivall:vscodium:monkey-patch , which allows customize-ui to work) and further down the line, some cooperation with VSCode's core team, or reverse-source mapping to access private / protected methods.