### PR TITLE
Use \r\n as newline separator for Windows

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -109,7 +109,7 @@ export class Script {
 
     command(line: string) {
         this.script += line;
-        this.script += "\n";
+        this.script += this.isWindows ? "\r\n" : "\n";
     }
 
     private folder: string;


### PR DESCRIPTION
I'm using Windows 10 and have been a fan of customize-ui extension.
A few months ago, suddenly monkey patch stopped working on my environment.
I don't know why, but after I changed the newline separator like this, it started to work again.
Please take a look.
